### PR TITLE
chore: bump actions to ratified manifest SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,15 +16,15 @@ jobs:
       - "run-id=${{ github.run_id }}"
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2
+        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2
         with:
           use-policy-store: true
           api-key: ${{ secrets.GH_FRESHAENGINEERING_STEP_SECURITY_API_KEY }}
 
-      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v2.3.4
 
       - name: Setup mise
-        uses: step-security/mise-action@2796166110dee826668caddd4bffedae5116e7cd # v4.2.0
+        uses: step-security/mise-action@6e96d2ffbc65c037f23c78818f2a339d6cf830f7 # v4.2.0
 
       - name: Install Dependencies
         run: |
@@ -41,15 +41,15 @@ jobs:
       - "run-id=${{ github.run_id }}"
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2
+        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2
         with:
           use-policy-store: true
           api-key: ${{ secrets.GH_FRESHAENGINEERING_STEP_SECURITY_API_KEY }}
 
-      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v2.3.4
 
       - name: Setup mise
-        uses: step-security/mise-action@2796166110dee826668caddd4bffedae5116e7cd # v4.2.0
+        uses: step-security/mise-action@6e96d2ffbc65c037f23c78818f2a339d6cf830f7 # v4.2.0
 
       - name: Install Dependencies
         run: |
@@ -66,14 +66,14 @@ jobs:
       - "run-id=${{ github.run_id }}"
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2
+        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2
         with:
           use-policy-store: true
           api-key: ${{ secrets.GH_FRESHAENGINEERING_STEP_SECURITY_API_KEY }}
 
-      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v2.3.4
 
       - name: Setup mise
-        uses: step-security/mise-action@2796166110dee826668caddd4bffedae5116e7cd # v4.2.0
+        uses: step-security/mise-action@6e96d2ffbc65c037f23c78818f2a339d6cf830f7 # v4.2.0
 
       - run: mix format --check-formatted


### PR DESCRIPTION
Manual rollout from actions-manifest's current ratified state (actions-maintenance.yaml not yet wired up in this repo).

- `actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f -> actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1`
- `step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 -> step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1`
- `step-security/mise-action@2796166110dee826668caddd4bffedae5116e7cd -> step-security/mise-action@6e96d2ffbc65c037f23c78818f2a339d6cf830f7`